### PR TITLE
Azure AD og fjerner Vault integrasjon

### DIFF
--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -16,7 +16,6 @@
   "env": {
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.preprod.local",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration",
-    "AZURE_V2_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/v2.0/.well-known/openid-configuration",
     "LAGRE_DOKUMENT_SCOPES": "97f0b1bc-6aa9-4d44-a3c7-60b4318fbec4/.default",
     "KAFKA_BOOTSTRAP_SERVERS": "b27apvl00045.preprod.local:8443,b27apvl00046.preprod.local:8443,b27apvl00047.preprod.local:8443"
   },

--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -4,6 +4,7 @@
   "namespace": "dusseldorf",
   "team": "dusseldorf",
   "tenant" : "trygdeetaten.no",
+  "omsorgspenger-api-cluster" : "dev-gcp",
   "minReplicas": "1",
   "maxReplicas": "2",
   "ingresses": [

--- a/nais/dev-fss.json
+++ b/nais/dev-fss.json
@@ -11,9 +11,6 @@
     "https://omsorgspenger-mottak.nais.preprod.local",
     "https://omsorgspenger-mottak.dev-fss-pub.nais.io"
   ],
-  "vaultKvPath": "/kv/preprod/fss/omsorgspenger-mottak/dusseldorf",
-  "azureadKvPath": "/azuread/data/dev/creds/omsorgspenger-mottak",
-  "serviceuserKvPath": "/serviceuser/data/dev/srvomsorgspeng-mtk",
   "env": {
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.preprod.local",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/966ac572-f5b7-4bbe-aa88-c76419c0f851/.well-known/openid-configuration",

--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -46,16 +46,9 @@ spec:
   prometheus:
     enabled: true
     path: /metrics
-  vault:
-    enabled: true
-    paths:
-      - mountPath: /var/run/secrets/nais.io/vault
-        kvPath: {{vaultKvPath}}
-      - mountPath: /var/run/secrets/nais.io/azuread
-        kvPath: {{azureadKvPath}}
-      - mountPath: /var/run/secrets/nais.io/serviceuser
-        kvPath: {{serviceuserKvPath}}
   webproxy: true
+  envFrom:
+    - secret: {{app}}
   env:
   {{#each env}}
      - name: {{@key}}

--- a/nais/naiserator.yml
+++ b/nais/naiserator.yml
@@ -11,6 +11,12 @@ spec:
     application:
       enabled: true
       tenant: {{tenant}}
+  accessPolicy:
+    inbound:
+      rules:
+        - application: omsorgspenger-api
+          namespace: dusseldorf
+          cluster: {{omsorgspenger-api-cluster}}
   port: 8080
   liveness:
     path: isalive

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -16,7 +16,6 @@
   "env": {
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.adeo.no",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/.well-known/openid-configuration",
-    "AZURE_V2_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/v2.0/.well-known/openid-configuration",
     "LAGRE_DOKUMENT_SCOPES": "0c5a6709-ba2a-42b7-bbfc-9b9f844e2ee2/.default",
     "KAFKA_BOOTSTRAP_SERVERS": "a01apvl00145.adeo.no:8443,a01apvl00146.adeo.no:8443,a01apvl00147.adeo.no:8443,a01apvl00148.adeo.no:8443,a01apvl00149.adeo.no:8443,a01apvl00150.adeo.no:8443"
   },

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -11,9 +11,6 @@
     "https://omsorgspenger-mottak.nais.adeo.no",
     "https://omsorgspenger-mottak.prod-fss-pub.nais.io"
   ],
-  "vaultKvPath": "/kv/prod/fss/omsorgspenger-mottak/dusseldorf",
-  "azureadKvPath": "/azuread/data/prod/creds/omsorgspenger-mottak",
-  "serviceuserKvPath": "/serviceuser/data/prod/srvomsorgspeng-mtk",
   "env": {
     "K9_DOKUMENT_BASE_URL": "https://k9-dokument.nais.adeo.no",
     "AZURE_V1_DISCOVERY_ENDPOINT": "https://login.microsoftonline.com/62366534-1ec3-4962-8869-9b5535279d0b/.well-known/openid-configuration",

--- a/nais/prod-fss.json
+++ b/nais/prod-fss.json
@@ -4,6 +4,7 @@
   "namespace": "dusseldorf",
   "team": "dusseldorf",
   "tenant" : "nav.no",
+  "omsorgspenger-api-cluster" : "prod-gcp",
   "minReplicas": "1",
   "maxReplicas": "2",
   "ingresses": [

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -53,9 +53,9 @@ nav {
         bootstrap_servers = ""
         bootstrap_servers = ${?KAFKA_BOOTSTRAP_SERVERS}
         username = ""
-        username = ${?NAIS_username}
+        username = ${?SRV_USERNAME}
         password = ""
-        password = ${?NAIS_password}
+        password = ${?SRV_PASSWORD}
     }
     trust_store {
         path = ""

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -16,7 +16,7 @@ nav {
             alias = "azure-v1"
             type = "azure"
             audience = ""
-            audience = ${?AZURE_CLIENT_ID}
+            audience = ${?AZURE_APP_CLIENT_ID}
             discovery_endpoint = ""
             discovery_endpoint = ${?AZURE_V1_DISCOVERY_ENDPOINT}
             azure {
@@ -27,9 +27,9 @@ nav {
             alias = "azure-v2"
             type = "azure"
             audience = ""
-            audience = ${?AZURE_CLIENT_ID}
+            audience = ${?AZURE_APP_CLIENT_ID}
             discovery_endpoint = ""
-            discovery_endpoint = ${?AZURE_V2_DISCOVERY_ENDPOINT}
+            discovery_endpoint = ${?AZURE_APP_WELL_KNOWN_URL}
             azure {
                 require_certificate_client_authentication = "true"
                 required_roles = "access_as_application"
@@ -38,11 +38,11 @@ nav {
         clients = [{
             alias = "azure-v2"
             client_id = ""
-            client_id = ${?AZURE_CLIENT_ID}
+            client_id = ${?AZURE_APP_CLIENT_ID}
             client_secret = ""
-            client_secret = ${?AZURE_CLIENT_SECRET}
+            client_secret = ${?AZURE_APP_CLIENT_SECRET}
             discovery_endpoint = ""
-            discovery_endpoint = ${?AZURE_V2_DISCOVERY_ENDPOINT}
+            discovery_endpoint = ${?AZURE_APP_WELL_KNOWN_URL}
         }]
         scopes = {
             lagre-dokument = ""


### PR DESCRIPTION
Bruke verdier fra Azure AD fra Nais og preautoriserer api.

Preautorisert tilgang til k9-dokument https://github.com/navikt/aad-iac/commit/8c6986660f6b5c5da130e97f444fcd9335d0dd49

Fjerner integrasjon med vault. Plukker secret opp fra clusteret. 
